### PR TITLE
Fix bug in webserver

### DIFF
--- a/util/network/RULES
+++ b/util/network/RULES
@@ -104,3 +104,8 @@ test(name = "util_test",
      src  = [ "util_test.cc" ],
      dep  = [ "util",
               "/public/test/cc/test_main" ])
+
+test(name = "webserver_test",
+     src  = [ "webserver_test.cc" ],
+     dep  = [ "webserver",
+              "/public/test/cc/test_main" ])

--- a/util/network/webserver.cc
+++ b/util/network/webserver.cc
@@ -17,9 +17,20 @@ bool WebServer::HttpRequestIsComplete(const string& r,
   // after two consecutive newlines.
   const char *start = r.c_str();
 
-  const char *s = strstr(start, "\n\n");
-  if (s == NULL)
-    s = strstr(start, "\r\n\r\n");
+  const char *s;
+
+  const char *nn_newlines = strstr(start, "\n\n");
+  const char *rnrn_newlines = strstr(start, "\r\n\r\n");
+
+  if (nn_newlines == NULL) {
+    s = rnrn_newlines;
+  } else if (rnrn_newlines == NULL) {
+    s = nn_newlines;
+  } else {
+    // if both newline types are found, choose the one that occurs first
+    // to represent the end of the header
+    s = (nn_newlines < rnrn_newlines) ? nn_newlines : rnrn_newlines;
+  }
 
   if (s == NULL)
     return false;

--- a/util/network/webserver_test.cc
+++ b/util/network/webserver_test.cc
@@ -1,0 +1,48 @@
+/*
+Copyright 2014, Room 77, Inc.
+@author sball
+
+Test for webserver
+*/
+
+#include "test/cc/test_main.h"
+#include "util/network/webserver.h"
+
+// Header uses \r\n
+TEST(WebserverTest, TestHttpRequestIsComplete_RNNewlines) {
+  string request =
+      "POST /_rpc HTTP/1.1\r\nUser-Agent: OpTripBot www.optrip.com\r\n"
+      "Accept-Encoding: gzip\r\nContent-Length: 11\r\n"
+      "Content-Type: text/xml; charset=utf-8\r\nConnection: Close\r\n"
+      "Host: localhost\r\nX-Forwarded-For: 192.168.77.52\r\n\r\nTESTCONTENT";
+  unsigned int request_size;
+
+  EXPECT_TRUE(WebServer::HttpRequestIsComplete(
+      request, &request_size, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL));
+}
+
+// Header uses \n
+TEST(WebserverTest, TestHttpRequestIsComplete_NNewlines) {
+  string request =
+      "POST /_rpc HTTP/1.1\nUser-Agent: OpTripBot www.optrip.com\n"
+      "Accept-Encoding: gzip\nContent-Length: 11\n"
+      "Content-Type: text/xml; charset=utf-8\nConnection: Close\n"
+      "Host: localhost\nX-Forwarded-For: 192.168.77.52\n\nTESTCONTENT";
+  unsigned int request_size;
+
+  EXPECT_TRUE(WebServer::HttpRequestIsComplete(
+      request, &request_size, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL));
+}
+
+// Header ends with \r\n\r\n\n
+TEST(WebserverTest, TestHttpRequestIsComplete_ConsecutiveNewlines) {
+  string request =
+      "POST /_rpc HTTP/1.1\r\nUser-Agent: OpTripBot www.optrip.com\r\n"
+      "Accept-Encoding: gzip\r\nContent-Length: 12\r\n"
+      "Content-Type: text/xml; charset=utf-8\r\nConnection: Close\r\n"
+      "Host: localhost\r\nX-Forwarded-For: 192.168.77.52\r\n\r\n\nTESTCONTENT";
+  unsigned int request_size;
+
+  EXPECT_TRUE(WebServer::HttpRequestIsComplete(
+      request, &request_size, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL));
+}


### PR DESCRIPTION
In webserver, the header boundary is indicated by consecutive newlines. The server first checks for `\n\n`, and if that is not found in the request, it then looks for `\r\n\r\n`. This method of looking for the header boundary is buggy and can result in `WebServer::HttpRequestIsComplete` incorrectly returning `false`.

For example, consider the following `POST` request:
`POST /_rpc HTTP/1.1\r\nUser-Agent: OpTripBot www.optrip.com\r\nAccept-Encoding: gzip\r\nContent-Length: 12\r\nContent-Type: text/xml; charset=utf-8\r\nConnection: Close\r\nHost: localhost\r\nX-Forwarded-For: 192.168.77.52\r\n\r\n\nTESTCONTENT`

The header boundary is `\r\n\r\n`, but since the body starts with `\n`, the server incorrectly thinks the header boundary is `\n\n`. The `header_len` is now off by one, and when the content length is calculated,

``` c++
if (request_is_post) {
    // a post request requires additional content
    const char *cl = strstr(start, "Content-Length: ");
    if (cl != NULL && cl < after_two_newlines)
      content_length = atoi(cl + 16);
    else
      content_length = 1;

    unsigned int total_size = header_len + content_length;
    if (request_size != NULL)
      *request_size = total_size;

    request_is_complete = (r.size() >= total_size);
  }
```

the request will be considered incomplete since the reported `Content-Length` is greater than the calculated content length.

This pull requests fixes this bug by always checking for both types of header boundaries and choosing which comes first as the boundary.
